### PR TITLE
Fixed findOneAndModify error for events

### DIFF
--- a/mongodb/spec/mongo-persistence-provider.spec.ts
+++ b/mongodb/spec/mongo-persistence-provider.spec.ts
@@ -1,16 +1,20 @@
-import { IPersistenceProvider, WorkflowInstance, ExecutionPointer } from "workflow-es";
+import { IPersistenceProvider, WorkflowInstance, ExecutionPointer, Event } from "workflow-es";
 import { MongoDBPersistence } from "../src/mongodb-provider";
 var stringify = require('json-stable-stringify');
 
 describe("mongodb-provider", () => {
     
     var persistence: IPersistenceProvider;
-    var wf1: WorkflowInstance;    
+    var wf1: WorkflowInstance;  
+    var ev1: Event;  
+    var ev2: Event;  
 
     beforeAll((done) => {
-        var mongoProvider = new MongoDBPersistence("mongodb://127.0.0.1:27019/tests");        
+        var mongoProvider = new MongoDBPersistence("mongodb://127.0.0.1:27019/tests");     
         mongoProvider.connect.then(() => {
+          
             persistence = mongoProvider;
+            
             done();
         });
     });
@@ -74,6 +78,119 @@ describe("mongodb-provider", () => {
                 })
                 .catch(done.fail);            
         });
+    });
+
+    describe("createEvent isProcessed:false", () => { 
+        var returnedId: string;
+        
+        beforeEach((done) => {
+            ev1 = new Event();
+            ev1.eventName = 'test-event';
+            ev1.eventKey = "1";
+            ev1.eventData = null;
+            ev1.eventTime = new Date();
+            ev1.isProcessed = false;
+            return persistence.createEvent(ev1)
+                .then(id => {
+                    returnedId = id;
+                    done();
+                })
+                .catch(done.fail);            
+        });
+
+        it("should return a generated id", function() {            
+            expect(returnedId).toBeDefined();
+        });
+
+        it("should return update original object with id", function() {            
+            expect(ev1.id).toBeDefined();
+        });
+    });
+    
+    describe("createEvent isProcessed:true", () => { 
+        var returnedId: string;
+        
+        beforeEach((done) => {
+            ev2 = new Event();
+            ev2.eventName = 'test-event';
+            ev2.eventKey = "1";
+            ev2.eventData = null;
+            ev2.eventTime = new Date();
+            ev2.isProcessed = true;
+            return persistence.createEvent(ev2)
+                .then(id => {
+                    returnedId = id;
+                    done();
+                })
+                .catch(done.fail);            
+        });
+
+        it("should return a generated id", function() {            
+            expect(returnedId).toBeDefined();
+        });
+
+        it("should return update original object with id", function() {            
+            expect(ev2.id).toBeDefined();
+        });
+    });
+    
+    describe("getRunnableEvents", () => {
+        var returnedEvents: Array<string>;
+        
+        beforeEach((done) => {
+          return persistence.getRunnableEvents()
+              .then( events => {
+                returnedEvents = events;
+                done();
+              })
+              .catch(done.fail);
+        });
+        
+        it("should contain previous event id", function() {
+          expect(returnedEvents).toContain(ev1.id);
+        });
+        
+    });
+
+    describe("markEventProcessed", () => {
+      var eventResult1: Event;
+        beforeEach((done) => {
+            return persistence.markEventProcessed(ev1.id)
+                .then(() => {
+                  persistence.getEvent(ev1.id)
+                    .then((event) => {
+                      eventResult1 = event;
+                      done();
+                    })
+                })
+                .catch(done.fail);
+        });
+
+        it("should be 'true'", () => {
+            expect(eventResult1.isProcessed).toEqual(true);
+        })
+        
+
+    });
+
+    describe("markEventUnprocessed", () => {
+        var eventResult2: Event;
+        beforeEach((done) => {
+            return persistence.markEventUnprocessed(ev2.id)
+                .then(() => {
+                  persistence.getEvent(ev2.id)
+                    .then((event) => {
+                      eventResult2 = event;
+                      done();
+                    })
+                })
+                .catch(done.fail);
+        });
+        
+        it("should be 'false'", () => {
+            expect(eventResult2.isProcessed).toEqual(false);
+        })
+        
     });
 
 });

--- a/mongodb/src/mongodb-provider.ts
+++ b/mongodb/src/mongodb-provider.ts
@@ -151,8 +151,8 @@ export class MongoDBPersistence implements IPersistenceProvider {
 
     public async getRunnableEvents(): Promise<Array<string>> {
         var self = this;
-        var deferred = new Promise<Array<string>>((resolve, reject) => {            
-            self.eventCollection.find({ isProcessed: false, eventTime : { $lt: Date.now() } }, { _id: 1 })
+        var deferred = new Promise<Array<string>>((resolve, reject) => {
+            self.eventCollection.find({ isProcessed: false, eventTime : { $lt: new Date() } }, { _id: 1 })
                 .toArray((err, data) => {
                     if (err)
                         reject(err);
@@ -167,9 +167,8 @@ export class MongoDBPersistence implements IPersistenceProvider {
     
     public async markEventProcessed(id: string): Promise<void> {
         var self = this;
-        let deferred = new Promise<void>((resolve, reject) => {            
-            var id = ObjectID(id);
-            self.eventCollection.findOneAndModify({ _id: id }, [['_id','asc']], { $set: { isProcessed: true } }, {}, 
+        let deferred = new Promise<void>((resolve, reject) => {
+            self.eventCollection.findOneAndUpdate({ _id: ObjectID(id) },{ $set: { isProcessed: true } }, { returnOriginal:true }, 
             (err, r) => {
                 if (err)
                     reject(err);
@@ -182,8 +181,7 @@ export class MongoDBPersistence implements IPersistenceProvider {
     public async markEventUnprocessed(id: string): Promise<void> {
         var self = this;
         let deferred = new Promise<void>((resolve, reject) => {            
-            var id = ObjectID(id);
-            self.eventCollection.findOneAndModify({ _id: id }, [['_id','asc']], { $set: { isProcessed: false } }, {}, 
+            self.eventCollection.findOneAndUpdate({ _id: ObjectID(id) }, { $set: { isProcessed: false } }, { returnOriginal:true }, 
             (err, r) => {
                 if (err)
                     reject(err);


### PR DESCRIPTION
* replaced findOneAndModify with findOneAndUpdate
* wrote new tests for creating processed and unprocessed events
* wrote new test for markEventProcessed
* wrote new test for markEventUnprocessed
* fixed an issue with Date.now() on ~~getRunnableInstances~~ (comment wrong - getRunnableEvents)
* wrote new test for ~~getRunnableInstances~~ getRunnableEvents
* NOTE: using two separate Event objects just to be sure
* General consistency with other findOneAndUpdate call

Daniel, I am hoping this is OK (excuse the errors in my commit comments).

I may have gone a bit overboard with the test variables for Event but just wanted to be sure I was using one for both types of update tests (one with `isProcessed=false` being set to `true` and the other with `isProcessed=true` being set to `false`).

I also wrote a test for `getRunnableEvents` as I had been having trouble with that. For some reason mongodb was not liking the date timestamp so I just changed it from `Date.now()` to `new Date()` - which seemed to fix everything (as they expect an ISODate).
