### PR TITLE
fix typescript compile error over typescript@2.4.1

### DIFF
--- a/core/src/models/workflow-step.ts
+++ b/core/src/models/workflow-step.ts
@@ -38,7 +38,7 @@ export class WorkflowStep<T extends StepBody> extends WorkflowStepBase {
     
     public body: { new(): T; };
     
-    public inputs: Array<(step: T, data: any) => void> = [];
-    public outputs: Array<(step: T, data: any) => void> = [];
+    public inputs: Array<(step: StepBody, data: any) => void> = [];
+    public outputs: Array<(step: StepBody, data: any) => void> = [];
     
 }


### PR DESCRIPTION
In typescript, function type can not use extended type, only can be the original type.