### PR TITLE
Dependency Injection in steps

### DIFF
--- a/core/src/abstractions/step-body.ts
+++ b/core/src/abstractions/step-body.ts
@@ -1,5 +1,7 @@
 import { ExecutionResult, StepExecutionContext } from "../models";
+import { injectable } from "inversify";
 
+@injectable()
 export abstract class StepBody {
 
     public abstract run(context: StepExecutionContext): Promise<ExecutionResult>;

--- a/core/src/config.ts
+++ b/core/src/config.ts
@@ -55,6 +55,7 @@ export function configureWorkflow(): WorkflowConfig {
     });
 
     let container = new Container();
+    container.bind(Container).toConstantValue(container);
     container.load(workflowModule);
 
     let config = new WorkflowConfig(container);

--- a/core/src/services/workflow-executor.ts
+++ b/core/src/services/workflow-executor.ts
@@ -1,4 +1,4 @@
-import { injectable, inject } from "inversify";
+import { injectable, inject, Container } from "inversify";
 import { IPersistenceProvider, ILogger, IWorkflowRegistry, IWorkflowExecutor, TYPES, IExecutionResultProcessor } from "../abstractions";
 import { WorkflowHost } from "./workflow-host";
 import { WorkflowInstance, WorkflowDefinition, ExecutionPointer, PointerStatus, ExecutionResult, StepExecutionContext, WorkflowStepBase, WorkflowStatus, ExecutionError, WorkflowErrorHandling, ExecutionPipelineDirective, WorkflowExecutorResult } from "../models";
@@ -14,6 +14,9 @@ export class WorkflowExecutor implements IWorkflowExecutor {
 
     @inject(TYPES.ILogger)
     private logger : ILogger;
+
+    @inject(Container)
+    private container : Container;
     
     public async execute(instance: WorkflowInstance): Promise<WorkflowExecutorResult> {
 
@@ -53,7 +56,7 @@ export class WorkflowExecutor implements IWorkflowExecutor {
                     stepContext.item = pointer.contextItem;
                     stepContext.pointer = pointer;
                     
-                    let body = new step.body(); //todo: di
+                    let body =  this.container.resolve(step.body);
 
                     //inputs
                     for (let input of step.inputs) {


### PR DESCRIPTION
Allows injecting steps with external dependencies, via:

```
var config = configureWorkflow();
config.getContainer().parent = myExternalContainer;
```