### PR TITLE
Update mongodb dependency to ^3.2.7

### DIFF
--- a/providers/workflow-es-mongodb/package.json
+++ b/providers/workflow-es-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-es-mongodb",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "MongoDB provider for Workflow ES",
   "main": "./build/src/index.js",
   "typings": "./build/src/index.d.ts",

--- a/providers/workflow-es-mongodb/package.json
+++ b/providers/workflow-es-mongodb/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "inversify": "^4.1.0",
     "json-stable-stringify": "^1.0.1",
-    "mongodb": "^2.2.11",
+    "mongodb": "^3.2.7",
     "reflect-metadata": "^0.1.10",
     "workflow-es": "^2.1.0"
   },

--- a/providers/workflow-es-mongodb/src/mongodb-provider.ts
+++ b/providers/workflow-es-mongodb/src/mongodb-provider.ts
@@ -13,11 +13,12 @@ export class MongoDBPersistence implements IPersistenceProvider {
     
     constructor(connectionString: string) {
         var self = this;
-        this.connect = new Promise<void>((resolve, reject) => {            
-            MongoClient.connect(connectionString, (err, db) => {
+        this.connect = new Promise<void>((resolve, reject) => {  
+            const options =  { useNewUrlParser: true,  useUnifiedTopology: true };
+            MongoClient.connect(connectionString, options, (err, client) => {
                 if (err)
                     reject(err);
-                self.db = db;
+                self.db = client.db();
                 self.workflowCollection = self.db.collection("workflows");
                 self.subscriptionCollection = self.db.collection("subscriptions");
                 self.eventCollection = self.db.collection("events");

--- a/providers/workflow-es-mongodb/src/mongodb-provider.ts
+++ b/providers/workflow-es-mongodb/src/mongodb-provider.ts
@@ -4,7 +4,7 @@ import { MongoClient, ObjectID } from "mongodb";
 export class MongoDBPersistence implements IPersistenceProvider {
 
     public connect: Promise<void>;
-    private db: any;
+    private client: any;
     private workflowCollection: any;
     private subscriptionCollection: any;
     private eventCollection: any;
@@ -18,10 +18,11 @@ export class MongoDBPersistence implements IPersistenceProvider {
             MongoClient.connect(connectionString, options, (err, client) => {
                 if (err)
                     reject(err);
-                self.db = client.db();
-                self.workflowCollection = self.db.collection("workflows");
-                self.subscriptionCollection = self.db.collection("subscriptions");
-                self.eventCollection = self.db.collection("events");
+                self.client = client;
+                const db = self.client.db();
+                self.workflowCollection = db.collection("workflows");
+                self.subscriptionCollection = db.collection("subscriptions");
+                self.eventCollection = db.collection("events");
                 resolve();
             });
         });        


### PR DESCRIPTION
workflow-es-monogodb has a dependency on [monogodb](https://www.npmjs.com/package/mongodb) ^2.2.11.

However, "[Versions of mongodb prior to 3.1.13 are vulnerable to Denial of Service](https://www.npmjs.com/advisories/1203)."

This pull updates the dependency to ^3.2.7.